### PR TITLE
fix s32 reading and writing

### DIFF
--- a/SwfLib.Avm2/Data/AbcDataReader.cs
+++ b/SwfLib.Avm2/Data/AbcDataReader.cs
@@ -417,26 +417,7 @@ namespace SwfLib.Avm2.Data {
         /// </summary>
         /// <returns></returns>
         private int ReadS32() {
-            uint val = 0;
-            var bt = _reader.ReadByte();
-            val |= bt & 0x7fu;
-            if ((bt & 0x80) == 0) return ((bt & 0x40) == 0) ? (int)val : (int)(val | 0xffffff80);
-
-            bt = _reader.ReadByte();
-            val |= (bt & 0x7fu) << 7;
-            if ((bt & 0x80) == 0) return ((bt & 0x40) == 0) ? (int)val : (int)(val | 0xffffc000);
-
-            bt = _reader.ReadByte();
-            val |= (bt & 0x7fu) << 14;
-            if ((bt & 0x80) == 0) return ((bt & 0x40) == 0) ? (int)val : (int)(val | 0xffe00000);
-
-            bt = _reader.ReadByte();
-            val |= (bt & 0x7fu) << 21;
-            if ((bt & 0x80) == 0) return ((bt & 0x40) == 0) ? (int)val : (int)(val | 0xf0000000);
-
-            bt = _reader.ReadByte();
-            val |= (bt & 0x7fu) << 28;
-            return (int)val;
+            return (int) ReadU32();
         }
 
         private uint[] ReadMultipleU30() {

--- a/SwfLib.Avm2/Data/AbcDataWriter.cs
+++ b/SwfLib.Avm2/Data/AbcDataWriter.cs
@@ -347,30 +347,7 @@ namespace SwfLib.Avm2.Data {
         }
 
         private void WriteS32(int val) {
-            var enc = (uint)val;
-            if (val >= 0) {
-                var hasNext = true;
-                do {
-                    if (enc < 0x40) {
-                        _writer.Write((byte)enc);
-                        hasNext = false;
-                    } else {
-                        _writer.Write((byte)(enc | 0x80));
-                    }
-                    enc >>= 7;
-                } while (hasNext);
-            } else {
-                var hasNext = true;
-                do {
-                    if (enc >= 0xffffffc0) {
-                        _writer.Write((byte)(enc & 0x7f));
-                        hasNext = false;
-                    } else {
-                        _writer.Write((byte)(enc | 0x80));
-                    }
-                    enc = (enc >> 7) | 0xfe000000;
-                } while (hasNext);
-            }
+            WriteU32((uint)val);
         }
 
         private void WriteD64(double val) {


### PR DESCRIPTION
The avm2 spec apparently lies and doesn't actually sign extend for s32

https://github.com/adobe/avmplus/blob/858d034a3bd3a54d9b70909386435cf4aec81d21/core/AbcParser-inlines.h#L17

s32: https://github.com/adobe/avmplus/blob/858d034a3bd3a54d9b70909386435cf4aec81d21/core/AbcParser.cpp#L1243
u32: https://github.com/adobe/avmplus/blob/858d034a3bd3a54d9b70909386435cf4aec81d21/core/AbcParser.cpp#L1267

u32 is the same as s32 just reinterpreted